### PR TITLE
Bug fix psl 7834

### DIFF
--- a/scripts/data_utils.py
+++ b/scripts/data_utils.py
@@ -146,9 +146,11 @@ class PdfTextSplitter(TextSplitter):
 
     def split_text(self, text: str) -> List[str]:
         content_dict, masked_text = self.mask_urls_and_imgs(text)
-        start_tag = self._table_tags["table_open"]
-        end_tag = self._table_tags["table_close"]
-        splits = masked_text.split(start_tag)
+        start_tags = [self._table_tags["table_open"] "<tabular>"]
+        end_tags = [self._table_tags["table_close"] "</tabular>"]
+        splits = masked_text
+        for start_tag in start_tags:
+            splits = splits.split(start_tag)
         
         final_chunks = self.chunk_rest(splits[0]) # the first split is before the first table tag so it is regular text
         
@@ -156,10 +158,12 @@ class PdfTextSplitter(TextSplitter):
         if len(final_chunks)>0:
             table_caption_prefix += self.extract_caption(final_chunks[-1]) # extracted from the last chunk before the table
         for part in splits[1:]:
-            table, rest = part.split(end_tag)
-            table = start_tag + table + end_tag 
-            minitables = self.chunk_table(table, table_caption_prefix)
-            final_chunks.extend(minitables)
+            for end_tag in part:
+                if end_tag in part:
+                   table, rest = part.split(end_tag)
+                   table = start_tags[0] + table + end_tags[0] 
+                   minitables = self.chunk_table(table, table_caption_prefix)
+                   final_chunks.extend(minitables)
 
             if rest.strip()!="":
                 text_minichunks = self.chunk_rest(rest)
@@ -167,7 +171,7 @@ class PdfTextSplitter(TextSplitter):
                 table_caption_prefix = self.extract_caption(text_minichunks[-1])
             else:
                 table_caption_prefix = ""
-            
+            break
 
         final_final_chunks = [chunk for chunk, chunk_size in merge_chunks_serially(final_chunks, self._chunk_size, content_dict)]
 

--- a/scripts/data_utils.py
+++ b/scripts/data_utils.py
@@ -146,8 +146,8 @@ class PdfTextSplitter(TextSplitter):
 
     def split_text(self, text: str) -> List[str]:
         content_dict, masked_text = self.mask_urls_and_imgs(text)
-        start_tags = [self._table_tags["table_open"] "<tabular>"]
-        end_tags = [self._table_tags["table_close"] "</tabular>"]
+        start_tags = [self._table_tags["table_open"], "<tabular>"]
+        end_tags = [self._table_tags["table_close"], "</tabular>"]
         splits = masked_text
         for start_tag in start_tags:
             splits = splits.split(start_tag)
@@ -165,13 +165,12 @@ class PdfTextSplitter(TextSplitter):
                    minitables = self.chunk_table(table, table_caption_prefix)
                    final_chunks.extend(minitables)
 
-            if rest.strip()!="":
-                text_minichunks = self.chunk_rest(rest)
-                final_chunks.extend(text_minichunks)
-                table_caption_prefix = self.extract_caption(text_minichunks[-1])
-            else:
-                table_caption_prefix = ""
-            break
+                if rest.strip()!="":
+                   text_minichunks = self.chunk_rest(rest)
+                   final_chunks.extend(text_minichunks)
+                   table_caption_prefix = self.extract_caption(text_minichunks[-1])
+                else:
+                   table_caption_prefix = ""
 
         final_final_chunks = [chunk for chunk, chunk_size in merge_chunks_serially(final_chunks, self._chunk_size, content_dict)]
 


### PR DESCRIPTION
### Motivation and Context
Bug: Browse experience provides inaccurate reference citations
Changes has been done on data_utils.py file.
Enhancement was done on code side to make understand the system "table "and "tabular" both on relevant context and give precise response.

Prior it was giving output like below :
<img width="430" alt="image" src="https://github.com/user-attachments/assets/f4348e8e-a19e-4364-8287-1451db9b0c49">
Now after enhancement it gives below output : 
<img width="505" alt="tabel and tabular" src="https://github.com/user-attachments/assets/f42b4bad-22ad-4b1a-a06f-32ce129c0aa5">


<!-- Thank you for your contribution to this repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required? 
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
  5. Does this solve an issue or add a feature that *all* users of this sample app can benefit from? Contributions will only be accepted that apply across all users of this app.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->


### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] I have built and tested the code locally and in a deployed app
- [ ] For frontend changes, I have pulled the latest code from main, built the frontend, and committed all static files.
- [ ] This is a change for all users of this app. No code or asset is specific to my use case or my organization.
- [ ] I didn't break any existing functionality :smile:
